### PR TITLE
Update layouts with monaco editor

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,3 +67,11 @@
     @apply bg-background text-foreground;
   }
 }
+
+.what-the-fuck-monaco {
+    font-family: 'Consolas', monospace;
+}
+
+.what-the-fuck-monaco * {
+    font-family: 'Consolas', monospace;
+}

--- a/src/app/submissions/[id]/page.tsx
+++ b/src/app/submissions/[id]/page.tsx
@@ -71,14 +71,16 @@ export default async function Submission({
   submission.taskTitle = Task.title
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex flex-col items-center justify-center h-screen py-10">
-          <p className="text-base animate-pulse">Loading...</p>
-        </div>
-      }
-    >
-      <SubmissionLayout submission={submission} />
-    </Suspense>
+    <div className="min-h-screen">
+      <Suspense
+        fallback={
+          <div className="flex flex-col items-center justify-center py-10">
+            <p className="text-base animate-pulse">Loading...</p>
+          </div>
+        }
+      >
+        <SubmissionLayout submission={submission} />
+      </Suspense>
+    </div>
   )
 }

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -28,14 +28,16 @@ export default async function Task({
   const task = await getTask(params.id)
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex flex-col items-center justify-center h-screen py-10">
-          <p className="text-base animate-pulse">Loading...</p>
-        </div>
-      }
-    >
-      <TaskLayout task={task} />
-    </Suspense>
+    <div className="min-h-screen flex">
+      <Suspense
+        fallback={
+          <div className="flex flex-col items-center justify-center h-screen py-10">
+            <p className="text-base animate-pulse">Loading...</p>
+          </div>
+        }
+      >
+        <TaskLayout task={task} />
+      </Suspense>
+    </div>
   )
 }

--- a/src/components/Submissionslayout.tsx
+++ b/src/components/Submissionslayout.tsx
@@ -69,12 +69,11 @@ export default function SubmissionLayout({ ...props }) {
         <p className="inline">{submission.memory} kB</p>
       </div>
       <div className="flex flex-col mt-5 space-y-4 lg:flex-row sm:space-x-4">
-        <Card className="w-[350px] sm:w-[500px] xl:w-[700px] h-[400px] overflow-hidden">
+        <Card className="w-[350px] sm:w-[500px] xl:w-[700px] 2xl:w-[800px] h-[600px] overflow-hidden">
           <Editor
             language={submission.language}
             value={submission.code}
             theme="vs-dark"
-            height="75vh"
             options={{
               minimap: { enabled: false },
               fontSize: 16,

--- a/src/components/Submissionslayout.tsx
+++ b/src/components/Submissionslayout.tsx
@@ -77,10 +77,11 @@ export default function SubmissionLayout({ ...props }) {
             height="75vh"
             options={{
               minimap: { enabled: false },
-              fontSize: 12,
+              fontSize: 16,
+              fontLigatures: true,
               readOnly: true,
             }}
-            className="caret-transparent"
+            className="caret-transparent what-the-fuck-monaco"
           />
         </Card>
       </div>

--- a/src/components/Tasklayout.tsx
+++ b/src/components/Tasklayout.tsx
@@ -118,9 +118,10 @@ export default function TaskLayout({ ...props }) {
             height="75vh"
             options={{
               minimap: { enabled: false },
-              fontSize: 12,
+              fontSize: 16,
+              fontLigatures: true,
             }}
-            className="caret-transparent"
+            className="caret-transparent what-the-fuck-monaco"
             onChange={handleEditorChange}
           />
         </Card>

--- a/src/components/Tasklayout.tsx
+++ b/src/components/Tasklayout.tsx
@@ -106,16 +106,14 @@ export default function TaskLayout({ ...props }) {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-10">
-      <p className="font-bold">{task.title}</p>
-      <p>{task.id}</p>
-      <div className="flex flex-col mt-5 space-y-4 lg:flex-row sm:space-x-4">
-        <Card className="w-[350px] sm:w-[500px] xl:w-[700px] h-[400px] overflow-hidden">
+    <div className="grow flex flex-col items-center justify-center py-10">
+      <h2 className="font-bold text-4xl">{task.title}</h2>
+      <div className="grow flex flex-col-reverse mt-5 space-y-4 lg:flex-row-reverse sm:space-x-4">
+        <Card className="w-[350px] sm:w-[500px] xl:w-[700px] 2xl:w-[800px] max-h-[600px] overflow-hidden my-4 lg:mx-8">
           <Editor
             language={language}
             value={sourcecode}
             theme="vs-dark"
-            height="75vh"
             options={{
               minimap: { enabled: false },
               fontSize: 16,
@@ -128,7 +126,7 @@ export default function TaskLayout({ ...props }) {
         <div className="flex flex-col space-y-5">
           <div className="inline">
             <p className="inline font-bold">Description: </p>
-            <Link href="#" target="_blank" className="hover:underline inline">
+            <Link href="#" target="_blank" className="hover:underline inline text-2xl">
               [{task.title}]
             </Link>
           </div>
@@ -136,7 +134,7 @@ export default function TaskLayout({ ...props }) {
             id="sourcecode"
             type="file"
             onChange={handleFileUpload}
-            className={fileInputColor}
+            className={`${fileInputColor} hover:cursor-pointer transition-transform scale-100 active:scale-95`}
           />
           <div className="flex flex-row space-x-4">
             <Select onValueChange={handleLanguage}>


### PR DESCRIPTION
# Update layouts with monaco editor

1. Fix monaco font (Temporarily)
I shamelessly select all descendant of the monaco editor and use monospace font
![image](https://github.com/chawinkn/quaso-grader/assets/115410150/d349947e-91dd-4394-bf73-8a977eaf971a)

2. Update the submission layout
Use the `min-h-screen`, reversed the containers, also adds new `2xl` media query for larger editor.
![image](https://github.com/chawinkn/quaso-grader/assets/115410150/81979c30-34dc-4342-8975-519ff5519800)

merge ด้วยไอเหี้ยกุง่วงแล้ว